### PR TITLE
Fix window size in windows 10 x64 #57

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,7 @@
 use crate::datatype::{Endianness, Signedness};
 
 pub const WIDTH: u32 = 1366;
-pub const HEIGHT: u32 = 1024;
+pub const HEIGHT: u32 = 800;
 
 #[derive(PartialEq)]
 pub enum PixelStyle {


### PR DESCRIPTION
The application window size in windows is grater than the window size in 1920x1080 resolution. The minimum possible window size needs to be smaller to fit in small screens.